### PR TITLE
refactor: enforce tina schema and content collection schema equality

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,8 +2,7 @@
   "files.associations": {
     "*.html": "handlebars"
   },
-  "typescript.experimental.useTsgo": true,
-  "typescript.tsserver.maxTsServerMemory": 4096,
+  "js/ts.experimental.useTsgo": true,
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "[svelte]": {

--- a/src/components/blocks/Footer.astro
+++ b/src/components/blocks/Footer.astro
@@ -1,9 +1,11 @@
 ---
 import { Icon } from "astro-icon/components";
-import { getConfig } from "../../lib/data";
 import Button from "../ui/Button.astro";
+import { Image } from "astro:assets";
+import { getEntry } from "astro:content";
 
-const config = (await getConfig()).data.config;
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+const config = (await getEntry("config", "config")!).data;
 const footerLogo = config.footerLogo;
 const contactLink = config.contactLink ? `/${config.contactLink}` : "/contact";
 
@@ -85,7 +87,7 @@ const social = [...(config.social ?? [])]
       <div class="mb-5 w-full lg:mb-0 lg:w-1/3">
         {
           footerLogo && (
-            <img
+            <Image
               src={footerLogo}
               alt="Babasarok logó"
               width={255}

--- a/src/components/blocks/Header.astro
+++ b/src/components/blocks/Header.astro
@@ -1,8 +1,10 @@
 ---
-import { getConfig } from "@/lib/data";
 import Button from "@/components/ui/Button.astro";
+import { Image } from "astro:assets";
+import { getEntry } from "astro:content";
 
-const config = (await getConfig()).data.config;
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+const config = (await getEntry("config", "config")!).data;
 const logo = config.logo;
 const contactLink = config.contactLink ? `/${config.contactLink}` : "/contact";
 
@@ -20,7 +22,7 @@ const mainMenu = rawMenu
       <a href="/" class="block shrink-0">
         {
           logo && (
-            <img
+            <Image
               src={logo}
               alt="Babasarok logó"
               width={200}

--- a/src/components/blocks/Product.astro
+++ b/src/components/blocks/Product.astro
@@ -29,8 +29,8 @@ const buttonHref = buttonTarget ? `/${buttonTarget}` : undefined;
             <ProductCard
               href={`/product/${product.id}/`}
               title={product.data.title}
-              image={product.data.thumbnail}
-              category={product.data.categories}
+              image={product.data.thumbnail ?? undefined}
+              category={product.data.categories ?? undefined}
               square
             />
           ))}

--- a/src/components/blocks/order/OrderDelivery.svelte
+++ b/src/components/blocks/order/OrderDelivery.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
   import Icon from "@iconify/svelte";
   import { marked } from "marked";
-  import type { CmsDeliveryMethod } from "@/lib/data";
+  import type { CmsEnhancedDeliveryMethod } from "@/lib/data";
 
   interface Props {
-    deliveryMethods: Record<string, CmsDeliveryMethod> | null;
+    deliveryMethods: Record<string, CmsEnhancedDeliveryMethod> | null;
     deliveryMethod: string;
   }
 

--- a/src/components/blocks/order/OrderForm.svelte
+++ b/src/components/blocks/order/OrderForm.svelte
@@ -10,15 +10,19 @@
   import Masonry from "svelte-bricks";
   import { submitOrder, calculateOrderTotal } from "@/lib/orderSubmit";
   import OrderDelivery from "./OrderDelivery.svelte";
-  import type { CmsConfig, CmsDeliveryMethod, CmsProduct } from "@/lib/data";
+  import type {
+    CmsEnhancedDeliveryMethod,
+    CmsEnhancedProduct,
+    CmsEnhancedConfig,
+  } from "@/lib/data";
   import type { IProduct } from "@/lib/types.svelte";
 
   import type { ProductMaterialValue } from "@/lib/types.svelte";
 
   interface Props {
-    products: Record<string, CmsProduct>;
-    deliveryMethods: Record<string, CmsDeliveryMethod>;
-    config: CmsConfig;
+    products: Record<string, CmsEnhancedProduct>;
+    deliveryMethods: Record<string, CmsEnhancedDeliveryMethod>;
+    config: CmsEnhancedConfig;
   }
 
   let { products: productInfo, deliveryMethods, config: params }: Props = $props();
@@ -178,7 +182,6 @@
                       fields: clone.fields?.filter((f) => f != null) ?? [],
                       materials: {
                         ...clone.materials,
-                        __typename: clone.materials?.__typename ?? "ProductMaterials",
                         materials: clone.materials?.materials?.filter((m) => m != null) ?? [],
                         banned_combinations:
                           clone.materials?.banned_combinations?.filter((c) => c != null) ?? [],

--- a/src/components/blocks/order/OrderItem.svelte
+++ b/src/components/blocks/order/OrderItem.svelte
@@ -27,7 +27,7 @@
         >
           <div
             class="bg-white w-6 h-6"
-            style={`-webkit-mask-image: url(${product.icon}); mask-image: url(${product.icon}); -webkit-mask-size: contain; mask-size: contain; -webkit-mask-position: center; mask-position: center; -webkit-mask-repeat: no-repeat; mask-repeat: no-repeat;`}
+            style={`-webkit-mask-image: url(${product.icon.src}); mask-image: url(${product.icon.src}); -webkit-mask-size: contain; mask-size: contain; -webkit-mask-position: center; mask-position: center; -webkit-mask-repeat: no-repeat; mask-repeat: no-repeat;`}
           ></div>
         </div>
       {:else}

--- a/src/components/blocks/order/OrderItemMaterials.svelte
+++ b/src/components/blocks/order/OrderItemMaterials.svelte
@@ -69,7 +69,7 @@
     for (const combination of product.materials.banned_combinations ?? []) {
       const combinationMaterialIds =
         combination?.materials
-          ?.map((item) => item?.material_path.material_id)
+          ?.map((item) => item?.material_path?.material_id)
           .filter((materialId): materialId is string => !!materialId) ?? [];
 
       if (combinationMaterialIds.length <= 1) {
@@ -160,11 +160,11 @@
       {#if multiColor}
         <div class="flex gap-1 flex-wrap">
           {#each value?.colors as colorId, index (colorId)}
-            {@const colorInfo = materialInfo?.colors?.find((c) => !!c && c.color_id === colorId)}
+            {@const colorInfo = materialInfo?.colors?.find((c) => c.color_id === colorId)}
             {#if colorInfo}
               <Chip
                 color={colorInfo.hex}
-                bgImage={colorInfo.image}
+                bgImage={colorInfo.image?.src}
                 onClose={() => {
                   const result = product;
                   if (result.materials.values[material_index]) {
@@ -184,7 +184,7 @@
       {/if}
       {#if (materialInfo?.colors?.length ?? 0) > 0}
         <div transition:slide class="flex gap-1 flex-wrap leading-0">
-          {#each materialInfo?.colors?.filter((x) => x != null) || [] as color (color.color_id)}
+          {#each materialInfo?.colors || [] as color (color.color_id)}
             {@const selected = value?.colors.includes(color.color_id)}
             <Color
               {color}

--- a/src/components/blocks/order/common/Color.svelte
+++ b/src/components/blocks/order/common/Color.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import type { GetImageResult } from "astro";
   import IconButton from "./IconButton.svelte";
   import Tooltip from "./Tooltip.svelte";
 
@@ -7,7 +8,7 @@
       color_id: string;
       hex?: string | undefined | null;
       label?: string | undefined | null;
-      image?: string | undefined | null;
+      image?: GetImageResult | undefined | null;
     };
     selected?: boolean;
     onclick?: (color_id: string) => void;
@@ -35,7 +36,7 @@
       ]}
     >
       {#if color.image}
-        <img src={color.image} alt="" class="block size-full rounded-full object-cover" />
+        <img {...color.image} alt="" class="block size-full rounded-full object-cover" />
       {:else}
         <div
           class="rounded-full h-full w-full"

--- a/src/components/blocks/order/common/Color.svelte
+++ b/src/components/blocks/order/common/Color.svelte
@@ -36,7 +36,13 @@
       ]}
     >
       {#if color.image}
-        <img {...color.image} alt="" class="block size-full rounded-full object-cover" />
+        <img
+          src={color.image.src}
+          srcset={color.image.srcSet.attribute || undefined}
+          {...color.image.attributes}
+          alt=""
+          class="block size-full rounded-full object-cover"
+        />
       {:else}
         <div
           class="rounded-full h-full w-full"

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -82,7 +82,7 @@ const product = defineCollection({
   schema: ({ image }) =>
     z.object({
       title: z.string(),
-      product_id: z.string().optional(),
+      product_id: z.string(),
       categories: z.string().optional(),
       date: z.coerce.date().optional(),
       thumbnail: image().optional(),
@@ -129,7 +129,7 @@ const material = defineCollection({
     z.object({
       title: z.string(),
       label: z.string().optional(),
-      material_id: z.string().optional(),
+      material_id: z.string(),
       thumbnail: image().optional(),
       categories: z.string().optional(),
       shortDescription: z.string().optional(),
@@ -144,6 +144,15 @@ const material = defineCollection({
         )
         .optional(),
     }),
+});
+
+const deliveryMethod = defineCollection({
+  loader: glob({ pattern: "*.md", base: "src/content/delivery-method" }),
+  schema: z.object({
+    delivery_name: z.string(),
+    name: z.string(),
+    price: z.number(),
+  }),
 });
 
 const contact = defineCollection({
@@ -163,4 +172,5 @@ export const collections = {
   heroBlock,
   servicesBlock,
   aboutBlock,
+  deliveryMethod,
 };

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -20,6 +20,7 @@
 import { defineCollection } from "astro:content";
 import { glob } from "astro/loaders";
 import z from "astro/zod";
+import type { SchemaContext } from "astro/content/config";
 
 const heroBlock = defineCollection({
   loader: glob({ pattern: "hero.md", base: "src/content/sections" }),
@@ -77,32 +78,94 @@ const config = defineCollection({
     }),
 });
 
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+const materialValidator = ({ image }: SchemaContext) =>
+  z.object({
+    material_id: z.string(),
+    label: z.string(),
+    categories: z.string().optional(),
+    shortDescription: z.string().optional(),
+    thumbnail: image().optional(),
+    colors: z
+      .array(
+        z.object({
+          color_id: z.string(),
+          label: z.string(),
+          hex: z.string().optional(),
+          image: image().optional(),
+        })
+      )
+      .optional(),
+  });
+
 const product = defineCollection({
   loader: glob({ pattern: "*.md", base: "src/content/product" }),
   schema: ({ image }) =>
     z.object({
-      title: z.string(),
       product_id: z.string(),
+      title: z.string(),
+      hidden_in_product_list: z.boolean().optional(),
+      can_be_ordered: z.boolean().optional(),
       categories: z.string().optional(),
       date: z.coerce.date().optional(),
       thumbnail: image().optional(),
       shortDescription: z.string().optional(),
-      hidden_in_product_list: z.boolean().optional(),
-      table: z
-        .array(
-          z.object({
-            title: z.string().nullable().optional(),
-            description: z.string().nullable().optional(),
-          })
-        )
-        .optional(),
+      icon: image().optional(),
+      priced_by_length: z.boolean().optional(),
+      price: z.number().optional(),
+      discount: z.number().optional(),
+      discount_valid_until: z.coerce.date().optional(),
       images: z
         .array(
-          z.object({
-            image: image().optional(),
-            description: z.string().optional(),
-          })
+          z
+            .object({
+              image: image().optional(),
+              description: z.string().optional(),
+            })
+            .optional()
         )
+        .optional(),
+      image: image().optional(),
+      table: z
+        .array(
+          z
+            .object({
+              title: z.string().optional(),
+              description: z.string().optional(),
+            })
+            .optional()
+        )
+        .optional(),
+      materials: z
+        .object({
+          material_required_count: z.number().optional(),
+          materials: z
+            .array(
+              z
+                .object({
+                  color_count: z.string().optional(),
+                  price: z.number().optional(),
+                  material_path: materialValidator({ image }),
+                })
+                .optional()
+            )
+            .optional(),
+          banned_combinations: z
+            .array(
+              z
+                .object({
+                  materials: z
+                    .array(
+                      z
+                        .object({ material_path: materialValidator({ image }).optional() })
+                        .optional()
+                    )
+                    .optional(),
+                })
+                .optional()
+            )
+            .optional(),
+        })
         .optional(),
     }),
 });
@@ -125,25 +188,7 @@ const blog = defineCollection({
 
 const material = defineCollection({
   loader: glob({ pattern: "*.md", base: "src/content/material" }),
-  schema: ({ image }) =>
-    z.object({
-      title: z.string(),
-      label: z.string().optional(),
-      material_id: z.string(),
-      thumbnail: image().optional(),
-      categories: z.string().optional(),
-      shortDescription: z.string().optional(),
-      colors: z
-        .array(
-          z.object({
-            color_id: z.string().optional(),
-            label: z.string().optional(),
-            hex: z.string().optional(),
-            image: image().optional(),
-          })
-        )
-        .optional(),
-    }),
+  schema: materialValidator,
 });
 
 const deliveryMethod = defineCollection({

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -72,9 +72,68 @@ const config = defineCollection({
       title: z.string(),
       logo: image().optional(),
       footerLogo: image().optional(),
-      favicon: image().optional(),
       description: z.string().optional(),
-      keywords: z.string().optional(),
+      blogPageURL: z.string().optional(),
+      contactLink: z.string().optional(),
+      copyright: z.string().optional(),
+      fabformURL: z.string().optional(),
+      address: z
+        .object({
+          phone: z.string().optional(),
+          email: z.string().optional(),
+          address: z.string().optional(),
+          openingHours: z.string().optional(),
+        })
+        .optional(),
+      footerContact: z
+        .object({
+          title: z.string().optional(),
+          button: z.string().optional(),
+          topTitle: z.string().optional(),
+        })
+        .optional(),
+      social: z
+        .array(
+          z
+            .object({
+              icon: z.string().optional(),
+              url: z.string().optional(),
+              weight: z.number().optional(),
+            })
+            .optional()
+        )
+        .optional(),
+      themeColor: z.string().optional(),
+      titleAddition: z.string().optional(),
+      titleSeparator: z.string().optional(),
+      mainMenu: z
+        .array(
+          z
+            .object({
+              name: z.string().optional(),
+              url: z.string().optional(),
+              weight: z.number().optional(),
+            })
+            .optional()
+        )
+        .optional(),
+      sitemapMenu: z
+        .array(
+          z
+            .object({
+              name: z.string().optional(),
+              url: z.string().optional(),
+              weight: z.number().optional(),
+            })
+            .optional()
+        )
+        .optional(),
+      ogLocale: z.string().optional(),
+      pagination: z
+        .object({
+          pagerSize: z.number().optional(),
+        })
+        .optional(),
     }),
 });
 
@@ -125,7 +184,6 @@ const product = defineCollection({
             .optional()
         )
         .optional(),
-      image: image().optional(),
       table: z
         .array(
           z

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -70,70 +70,79 @@ const config = defineCollection({
   schema: ({ image }) =>
     z.object({
       title: z.string(),
-      logo: image().optional(),
-      footerLogo: image().optional(),
-      description: z.string().optional(),
-      blogPageURL: z.string().optional(),
-      contactLink: z.string().optional(),
-      copyright: z.string().optional(),
-      fabformURL: z.string().optional(),
+      logo: image().optional().nullable(),
+      footerLogo: image().optional().nullable(),
+      description: z.string().optional().nullable(),
+      blogPageURL: z.string().optional().nullable(),
+      contactLink: z.string().optional().nullable(),
+      copyright: z.string().optional().nullable(),
+      fabformURL: z.string().optional().nullable(),
       address: z
         .object({
-          phone: z.string().optional(),
-          email: z.string().optional(),
-          address: z.string().optional(),
-          openingHours: z.string().optional(),
+          phone: z.string().optional().nullable(),
+          email: z.string().optional().nullable(),
+          address: z.string().optional().nullable(),
+          openingHours: z.string().optional().nullable(),
         })
-        .optional(),
+        .optional()
+        .nullable(),
       footerContact: z
         .object({
-          title: z.string().optional(),
-          button: z.string().optional(),
-          topTitle: z.string().optional(),
+          title: z.string().optional().nullable(),
+          button: z.string().optional().nullable(),
+          topTitle: z.string().optional().nullable(),
         })
-        .optional(),
+        .optional()
+        .nullable(),
       social: z
         .array(
           z
             .object({
-              icon: z.string().optional(),
-              url: z.string().optional(),
-              weight: z.number().optional(),
+              icon: z.string().optional().nullable(),
+              url: z.string().optional().nullable(),
+              weight: z.number().optional().nullable(),
             })
             .optional()
+            .nullable()
         )
-        .optional(),
-      themeColor: z.string().optional(),
-      titleAddition: z.string().optional(),
-      titleSeparator: z.string().optional(),
+        .optional()
+        .nullable(),
+      themeColor: z.string().optional().nullable(),
+      titleAddition: z.string().optional().nullable(),
+      titleSeparator: z.string().optional().nullable(),
       mainMenu: z
         .array(
           z
             .object({
-              name: z.string().optional(),
-              url: z.string().optional(),
-              weight: z.number().optional(),
+              name: z.string().optional().nullable(),
+              url: z.string().optional().nullable(),
+              weight: z.number().optional().nullable(),
             })
             .optional()
+            .nullable()
         )
-        .optional(),
+        .optional()
+        .nullable(),
       sitemapMenu: z
         .array(
           z
             .object({
-              name: z.string().optional(),
-              url: z.string().optional(),
-              weight: z.number().optional(),
+              name: z.string().optional().nullable(),
+              url: z.string().optional().nullable(),
+              weight: z.number().optional().nullable(),
             })
             .optional()
+            .nullable()
         )
-        .optional(),
-      ogLocale: z.string().optional(),
+        .optional()
+        .nullable(),
+      ogLocale: z.string().optional().nullable(),
       pagination: z
         .object({
-          pagerSize: z.number().optional(),
+          pagerSize: z.number().optional().nullable(),
         })
-        .optional(),
+        .optional()
+        .nullable(),
     }),
 });
 
@@ -142,19 +151,20 @@ const materialValidator = ({ image }: SchemaContext) =>
   z.object({
     material_id: z.string(),
     label: z.string(),
-    categories: z.string().optional(),
-    shortDescription: z.string().optional(),
-    thumbnail: image().optional(),
+    categories: z.string().optional().nullable(),
+    shortDescription: z.string().optional().nullable(),
+    thumbnail: image().optional().nullable(),
     colors: z
       .array(
         z.object({
           color_id: z.string(),
           label: z.string(),
-          hex: z.string().optional(),
-          image: image().optional(),
+          hex: z.string().optional().nullable(),
+          image: image().optional().nullable(),
         })
       )
-      .optional(),
+      .optional()
+      .nullable(),
   });
 
 const product = defineCollection({
@@ -163,51 +173,57 @@ const product = defineCollection({
     z.object({
       product_id: z.string(),
       title: z.string(),
-      hidden_in_product_list: z.boolean().optional(),
-      can_be_ordered: z.boolean().optional(),
-      categories: z.string().optional(),
-      date: z.coerce.date().optional(),
-      thumbnail: image().optional(),
-      shortDescription: z.string().optional(),
-      icon: image().optional(),
-      priced_by_length: z.boolean().optional(),
-      price: z.number().optional(),
-      discount: z.number().optional(),
-      discount_valid_until: z.coerce.date().optional(),
+      hidden_in_product_list: z.boolean().optional().nullable(),
+      can_be_ordered: z.boolean().optional().nullable(),
+      categories: z.string().optional().nullable(),
+      date: z.coerce.date().optional().nullable(),
+      thumbnail: image().optional().nullable(),
+      shortDescription: z.string().optional().nullable(),
+      icon: image().optional().nullable(),
+      priced_by_length: z.boolean().optional().nullable(),
+      price: z.number().optional().nullable(),
+      discount: z.number().optional().nullable(),
+      discount_valid_until: z.coerce.date().optional().nullable(),
       images: z
         .array(
           z
             .object({
-              image: image().optional(),
-              description: z.string().optional(),
+              image: image().optional().nullable(),
+              description: z.string().optional().nullable(),
             })
             .optional()
+            .nullable()
         )
-        .optional(),
+        .optional()
+        .nullable(),
       table: z
         .array(
           z
             .object({
-              title: z.string().optional(),
-              description: z.string().optional(),
+              title: z.string().optional().nullable(),
+              description: z.string().optional().nullable(),
             })
             .optional()
+            .nullable()
         )
-        .optional(),
+        .optional()
+        .nullable(),
       materials: z
         .object({
-          material_required_count: z.number().optional(),
+          material_required_count: z.number().optional().nullable(),
           materials: z
             .array(
               z
                 .object({
-                  color_count: z.string().optional(),
-                  price: z.number().optional(),
-                  material_path: materialValidator({ image }),
+                  color_count: z.string().optional().nullable(),
+                  price: z.number().optional().nullable(),
+                  material_path: z.string(),
                 })
                 .optional()
+                .nullable()
             )
-            .optional(),
+            .optional()
+            .nullable(),
           banned_combinations: z
             .array(
               z
@@ -215,16 +231,21 @@ const product = defineCollection({
                   materials: z
                     .array(
                       z
-                        .object({ material_path: materialValidator({ image }).optional() })
+                        .object({ material_path: z.string().optional().nullable() })
                         .optional()
+                        .nullable()
                     )
-                    .optional(),
+                    .optional()
+                    .nullable(),
                 })
                 .optional()
+                .nullable()
             )
-            .optional(),
+            .optional()
+            .nullable(),
         })
-        .optional(),
+        .optional()
+        .nullable(),
     }),
 });
 

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -246,6 +246,39 @@ const product = defineCollection({
         })
         .optional()
         .nullable(),
+      fields: z
+        .array(
+          z
+            .object({
+              name: z.string(),
+              length_based_pricing_source: z.boolean().optional().nullable(),
+              price: z.number().optional().nullable(),
+              label: z.string(),
+              type: z.string(),
+              optional: z.boolean().optional().nullable(),
+              allow_custom_value: z.boolean().optional().nullable(),
+              regex: z.string().optional().nullable(),
+              placeholder: z.string().optional().nullable(),
+              items: z
+                .array(
+                  z
+                    .object({
+                      value: z.string(),
+                      label: z.string().optional().nullable(),
+                      price: z.number().optional().nullable(),
+                      tooltip: z.string().optional().nullable(),
+                    })
+                    .optional()
+                    .nullable()
+                )
+                .optional()
+                .nullable(),
+            })
+            .optional()
+            .nullable()
+        )
+        .optional()
+        .nullable(),
     }),
 });
 
@@ -271,7 +304,7 @@ const material = defineCollection({
 });
 
 const deliveryMethod = defineCollection({
-  loader: glob({ pattern: "*.md", base: "src/content/delivery-method" }),
+  loader: glob({ pattern: "*.md", base: "src/content/delivery_method" }),
   schema: z.object({
     delivery_name: z.string(),
     name: z.string(),

--- a/src/content/material/_index.html
+++ b/src/content/material/_index.html
@@ -1,3 +1,0 @@
----
-title: "Anyagok"
----

--- a/src/content/product/_index.html
+++ b/src/content/product/_index.html
@@ -1,3 +1,0 @@
----
-title: Termékek
----

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -27,7 +27,7 @@ interface Props {
 
 const { title, description, image, isArticle = false, robots = "index, follow" } = Astro.props;
 
-const config = (await getConfig()).data.config;
+const config = await getConfig();
 const canonicalURL = new URL(Astro.url.pathname, Astro.site ?? Astro.url.origin);
 const ogLocale = config.ogLocale ?? "hu_HU";
 const themeColor = config.themeColor ?? "#F1D3B2";

--- a/src/lib/__tests__/fixtures.ts
+++ b/src/lib/__tests__/fixtures.ts
@@ -15,7 +15,7 @@ import type {
   ProductMaterialValue,
   ValueWithError,
 } from "@/lib/types.svelte";
-import type { CmsDeliveryMethod } from "@/lib/data";
+import type { CmsEnhancedDeliveryMethod } from "@/lib/data";
 
 type FieldType = "input" | "select" | "radio" | "color" | "toggle";
 
@@ -47,7 +47,7 @@ export function makeField(opts: FieldOpts): Field {
     ...rest,
     ...(items ? { items: items.map((i) => ({ label: i.value, ...i })) } : {}),
     ...(value ? { value } : {}),
-  } as unknown as Field;
+  };
 }
 
 interface MaterialColor {
@@ -120,11 +120,10 @@ export function makeDelivery(
   name = "Személyes átvétel",
   price = 0,
   delivery_name = "szemelyes"
-): CmsDeliveryMethod {
+): CmsEnhancedDeliveryMethod {
   return {
-    __typename: "Delivery_methods",
     delivery_name,
     name,
     price,
-  } as unknown as CmsDeliveryMethod;
+  };
 }

--- a/src/lib/assets.ts
+++ b/src/lib/assets.ts
@@ -42,7 +42,7 @@ export async function resolveImage(options: UnresolvedImageTransform): Promise<G
   // to the path relative to the media root (`src/assets`).
   const tinaPath = tinaCloudMediaPath(clean);
   if (tinaPath) {
-    return getImage({ ...options, src: clean });
+    return getImage({ ...options, src: clean, inferSize: true });
   }
 
   // Strip an optional leading slash and the `src/assets/` media-root prefix.

--- a/src/lib/assets.ts
+++ b/src/lib/assets.ts
@@ -12,20 +12,25 @@
  *   published `https://assets.tina.io/<id>/<path>`
  * We reduce either back to the media-root-relative path so it still resolves.
  */
-import type { ImageMetadata } from "astro";
+import type { GetImageResult, ImageMetadata, UnresolvedImageTransform } from "astro";
 import { tinaCloudMediaPath } from "./tinaImageUrl";
+import { getImage } from "astro:assets";
 
 const images = import.meta.glob<ImageMetadata>(
   "../assets/**/*.{jpg,jpeg,png,gif,svg,webp,avif,JPG,JPEG,PNG}",
   { eager: true, import: "default" }
 );
 
-export function resolveImage(path: string | null | undefined): ImageMetadata | undefined {
-  if (!path) {
-    return undefined;
+export async function resolveImage(options: UnresolvedImageTransform): Promise<GetImageResult> {
+  let clean: string;
+  if (typeof options.src === "string") {
+    clean = options.src;
+  } else if (typeof options.src === "object" && "src" in options.src) {
+    clean = options.src.src;
+  } else {
+    const src = await options.src;
+    clean = src.default.src;
   }
-
-  let clean = path;
 
   try {
     clean = decodeURIComponent(clean);
@@ -37,11 +42,11 @@ export function resolveImage(path: string | null | undefined): ImageMetadata | u
   // to the path relative to the media root (`src/assets`).
   const tinaPath = tinaCloudMediaPath(clean);
   if (tinaPath) {
-    clean = tinaPath;
+    return getImage({ ...options, src: clean });
   }
 
   // Strip an optional leading slash and the `src/assets/` media-root prefix.
   clean = clean.replace(/^\/?(src\/assets\/)?/, "");
 
-  return images[`../assets/${clean}`];
+  return getImage({ ...options, src: images[`../assets/${clean}`] });
 }

--- a/src/lib/assets.ts
+++ b/src/lib/assets.ts
@@ -42,11 +42,10 @@ export async function resolveImage(options: UnresolvedImageTransform): Promise<G
   // to the path relative to the media root (`src/assets`).
   const tinaPath = tinaCloudMediaPath(clean);
   if (tinaPath) {
-    return getImage({ inferSize: true, ...options, src: tinaPath });
+    clean = tinaPath;
   }
 
   // Strip an optional leading slash and the `src/assets/` media-root prefix.
   clean = clean.replace(/^\/?(src\/assets\/)?/, "");
-
   return getImage({ ...options, src: images[`../assets/${clean}`] });
 }

--- a/src/lib/assets.ts
+++ b/src/lib/assets.ts
@@ -42,7 +42,7 @@ export async function resolveImage(options: UnresolvedImageTransform): Promise<G
   // to the path relative to the media root (`src/assets`).
   const tinaPath = tinaCloudMediaPath(clean);
   if (tinaPath) {
-    return getImage({ ...options, src: clean, inferSize: true });
+    return getImage({ inferSize: true, ...options, src: tinaPath });
   }
 
   // Strip an optional leading slash and the `src/assets/` media-root prefix.

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -21,6 +21,7 @@ import {
   type RecursiveDiff,
   type RecursivelyNullableToUndefined,
   type RecursivelyRemoveKeys,
+  type RecursivelyReplaceKeyType,
   type RecursivelyReplaceType,
   type RecursiveRequired,
 } from "./typeUtils";
@@ -44,7 +45,7 @@ type CmsOriginalDeliveryMethod = Awaited<
 type CmsDeliveryMethod = RecursivelyNullableToUndefined<
   RecursivelyRemoveKeys<CmsOriginalDeliveryMethod, `_${string}`>
 >;
-interface CmsEnhancedDeliveryMethod extends Omit<CmsDeliveryMethod, "id"> {}
+export interface CmsEnhancedDeliveryMethod extends Omit<CmsDeliveryMethod, "id"> {}
 
 type AstroDeliveryMethod = InferEntrySchema<"deliveryMethod">;
 AssertTrue<IfEquals<CmsEnhancedDeliveryMethod, AstroDeliveryMethod>>();
@@ -112,7 +113,9 @@ interface CmsEnhancedProductMaterials extends Omit<
   banned_combinations?:
     Array<CmsEnhancedProductMaterialsBannedCombination | undefined | null> | undefined | null;
 }
-interface CmsEnhancedProduct extends Omit<
+
+type CmsField = NonNullable<NonNullable<CmsProduct["fields"]>[number]>;
+export interface CmsEnhancedProduct extends Omit<
   CmsProduct,
   | "id"
   | "date"
@@ -130,9 +133,14 @@ interface CmsEnhancedProduct extends Omit<
   date?: Date | undefined | null;
   images?: Array<CmsEnhancedProductImage | undefined | null> | undefined | null;
   materials?: CmsEnhancedProductMaterials | undefined | null;
+  fields?: Array<CmsField | undefined | null> | undefined | null;
 }
 
-type AstroProduct = RecursivelyReplaceType<InferEntrySchema<"product">, Image, GetImageResult>;
+type AstroProduct = RecursivelyReplaceKeyType<
+  RecursivelyReplaceType<InferEntrySchema<"product">, Image, GetImageResult>,
+  "material_path",
+  CmsEnhancedMaterial
+>;
 type ProductDiff = RecursiveDiff<CmsEnhancedProduct, AstroProduct>;
 AssertTrue<IfEquals<ProductDiff, never>>();
 
@@ -147,10 +155,10 @@ type CmsConfig = RecursivelyNullableToUndefined<
   >
 >;
 
-type CmsEnhancedConfig = Omit<CmsConfig, "logo" | "footerLogo" | "id"> & {
+export interface CmsEnhancedConfig extends Omit<CmsConfig, "logo" | "footerLogo" | "id"> {
   logo?: GetImageResult | undefined | null;
   footerLogo?: GetImageResult | undefined | null;
-};
+}
 
 type AstroConfig = RecursivelyReplaceType<InferEntrySchema<"config">, Image, GetImageResult>;
 type ConfigDiff = RecursiveDiff<CmsEnhancedConfig, AstroConfig>;
@@ -187,7 +195,7 @@ async function optimizeImage(path: string, width: number): Promise<GetImageResul
     return { src: path, options: { width, format: "webp" } };
   }
   const optimized = await getImage({ src: meta, width, format: "webp" });
-  return optimized;
+  return { ...optimized };
 }
 
 // Render widths (2x for retina) for images consumed outside `<Image>`.
@@ -314,6 +322,29 @@ export const getProducts = async (): Promise<CmsEnhancedProduct[]> => {
           .map((row) => ({
             description: row.description ?? undefined,
             title: row.title ?? undefined,
+          })) ?? undefined,
+      fields:
+        product.fields
+          ?.filter((field) => field != null)
+          .map((field) => ({
+            allow_custom_value: field.allow_custom_value ?? undefined,
+            label: field.label,
+            length_based_pricing_source: field.length_based_pricing_source ?? undefined,
+            name: field.name,
+            optional: field.optional ?? undefined,
+            type: field.type,
+            placeholder: field.placeholder ?? undefined,
+            price: field.price ?? undefined,
+            regex: field.regex ?? undefined,
+            items:
+              field.items
+                ?.filter((item) => item != null)
+                .map((item) => ({
+                  label: item.label,
+                  value: item.value,
+                  price: item.price ?? undefined,
+                  tooltip: item.tooltip ?? undefined,
+                })) ?? undefined,
           })) ?? undefined,
     });
   }

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -15,6 +15,54 @@ import { getImage } from "astro:assets";
 import { requestWithMetadata } from "@tinacms/astro/data";
 import client from "../../tina/__generated__/client";
 import { resolveImage } from "./assets";
+import {
+  AssertTrue,
+  type IfEquals,
+  type RecursivelyNullableToUndefined,
+  type RecursivelyRemoveKeys,
+} from "./typeUtils";
+import type { InferEntrySchema } from "astro:content";
+
+type CmsDeliveryMethod = RecursivelyNullableToUndefined<
+  RecursivelyRemoveKeys<
+    Awaited<ReturnType<typeof client.queries.delivery_methods>>["data"]["delivery_methods"],
+    `_${string}`
+  >
+>;
+
+interface CmsEnhancedDeliveryMethod extends Omit<CmsDeliveryMethod, "id"> {}
+
+type CmsMaterial = RecursivelyRemoveKeys<
+  Awaited<ReturnType<typeof client.queries.product_materials>>["data"]["product_materials"],
+  `_${string}`
+>;
+
+interface CmsEnhancedMaterial extends Omit<CmsMaterial, "id" | "thumbnail"> {
+  thumbnail?: ImageMetadata;
+  colors?: Array<
+    Omit<CmsMaterial["colors"][number], "image"> & {
+      image?: ImageMetadata;
+    }
+  >;
+}
+type CmsProduct = RecursivelyNullableToUndefined<
+  RecursivelyRemoveKeys<
+    Awaited<ReturnType<typeof client.queries.product>>["data"]["product"],
+    `_${string}`
+  >
+>;
+type CmsConfig = RecursivelyRemoveKeys<
+  Awaited<ReturnType<typeof client.queries.config>>["data"]["config"],
+  `_${string}`
+>;
+
+type AstroDeliveryMethod = InferEntrySchema<"deliveryMethod">;
+type AstroMaterial = InferEntrySchema<"material">;
+type AstroProduct = InferEntrySchema<"product">;
+type AstroConfig = InferEntrySchema<"config">;
+
+AssertTrue<IfEquals<CmsEnhancedDeliveryMethod, AstroDeliveryMethod>>();
+AssertTrue<IfEquals<CmsEnhancedMaterial, AstroMaterial>>();
 
 /**
  * Resolve every image reference in a loaded entity to its hashed local `src`.
@@ -153,8 +201,3 @@ export const getDeliveryMethods = async () => {
 
   return nodesFrom(result.data.delivery_methodsConnection);
 };
-
-export type CmsConfig = Awaited<ReturnType<typeof getConfig>>["data"]["config"];
-export type CmsProduct = Awaited<ReturnType<typeof getProducts>>[number];
-export type CmsMaterial = Awaited<ReturnType<typeof getMaterials>>[number];
-export type CmsDeliveryMethod = Awaited<ReturnType<typeof getDeliveryMethods>>[number];

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -18,10 +18,18 @@ import { resolveImage } from "./assets";
 import {
   AssertTrue,
   type IfEquals,
+  type NullableToUndefined,
+  type RecursiveDiff,
   type RecursivelyNullableToUndefined,
   type RecursivelyRemoveKeys,
 } from "./typeUtils";
 import type { InferEntrySchema } from "astro:content";
+import type { ImageFunction } from "astro/content/config";
+import type { z } from "astro/zod";
+
+type Image = z.infer<ReturnType<ImageFunction>>;
+
+// #region DeliveryMethod
 
 type CmsDeliveryMethod = RecursivelyNullableToUndefined<
   RecursivelyRemoveKeys<
@@ -29,40 +37,114 @@ type CmsDeliveryMethod = RecursivelyNullableToUndefined<
     `_${string}`
   >
 >;
-
 interface CmsEnhancedDeliveryMethod extends Omit<CmsDeliveryMethod, "id"> {}
 
-type CmsMaterial = RecursivelyRemoveKeys<
-  Awaited<ReturnType<typeof client.queries.product_materials>>["data"]["product_materials"],
-  `_${string}`
+type AstroDeliveryMethod = InferEntrySchema<"deliveryMethod">;
+AssertTrue<IfEquals<CmsEnhancedDeliveryMethod, AstroDeliveryMethod>>();
+
+// #endregion
+
+// #region Material
+
+type CmsMaterialColor = NonNullable<NonNullable<CmsMaterial["colors"]>[number]>;
+type CmsMaterial = RecursivelyNullableToUndefined<
+  RecursivelyRemoveKeys<
+    Awaited<ReturnType<typeof client.queries.product_materials>>["data"]["product_materials"],
+    `_${string}`
+  >
 >;
 
-interface CmsEnhancedMaterial extends Omit<CmsMaterial, "id" | "thumbnail"> {
-  thumbnail?: ImageMetadata;
-  colors?: Array<
-    Omit<CmsMaterial["colors"][number], "image"> & {
-      image?: ImageMetadata;
-    }
-  >;
+interface CmsEnhancedMaterialColor extends Omit<CmsMaterialColor, "image"> {
+  image?: Image | undefined;
 }
+interface CmsEnhancedMaterial extends Omit<CmsMaterial, "id" | "thumbnail" | "colors" | "content"> {
+  thumbnail?: Image | undefined;
+  colors?: Array<CmsEnhancedMaterialColor> | undefined;
+}
+
+type AstroMaterial = InferEntrySchema<"material">;
+type MaterialDiff = RecursiveDiff<CmsEnhancedMaterial, AstroMaterial>;
+AssertTrue<IfEquals<MaterialDiff, never>>();
+
+// #endregion
+// #region Product
 type CmsProduct = RecursivelyNullableToUndefined<
   RecursivelyRemoveKeys<
     Awaited<ReturnType<typeof client.queries.product>>["data"]["product"],
     `_${string}`
   >
 >;
+
+type CmsProductImage = NonNullable<NonNullable<CmsProduct["images"]>[number]>;
+type CmsProductMaterials = NonNullable<CmsProduct["materials"]>;
+type CmsProductMaterial = NonNullable<NonNullable<CmsProduct["materials"]>["materials"]>[number];
+type CmsProductMaterialsBannedCombination = NonNullable<
+  NonNullable<NonNullable<CmsProduct["materials"]>["banned_combinations"]>[number]
+>;
+
+interface CmsEnhancedProductImage extends Omit<CmsProductImage, "image"> {
+  image?: Image | undefined;
+}
+
+interface CmsEnhancedProductMaterial extends Omit<
+  NonNullable<CmsProductMaterial>,
+  "material_path"
+> {
+  material_path: CmsEnhancedMaterial;
+}
+
+interface CmsEnhancedProductMaterialsBannedCombination extends Omit<
+  NonNullable<CmsProductMaterialsBannedCombination>,
+  "materials"
+> {
+  materials?: Array<{ material_path?: CmsEnhancedMaterial | undefined } | undefined> | undefined;
+}
+
+interface CmsEnhancedProductMaterials extends Omit<
+  CmsProductMaterials,
+  "materials" | "banned_combinations"
+> {
+  materials?: Array<CmsEnhancedProductMaterial | undefined> | undefined;
+  banned_combinations?: Array<CmsEnhancedProductMaterialsBannedCombination | undefined> | undefined;
+}
+interface CmsEnhancedProduct extends Omit<
+  CmsProduct,
+  | "id"
+  | "date"
+  | "thumbnail"
+  | "content"
+  | "discount_valid_until"
+  | "images"
+  | "image"
+  | "materials"
+  | "fields"
+  | "icon"
+> {
+  thumbnail?: Image | undefined;
+  discount_valid_until?: Date | undefined;
+  image?: Image | undefined;
+  icon?: Image | undefined;
+  date?: Date | undefined;
+  images?: Array<CmsEnhancedProductImage | undefined> | undefined;
+  materials?: CmsEnhancedProductMaterials | undefined;
+}
+
+type AstroProduct = InferEntrySchema<"product">;
+type ProductDiff = RecursiveDiff<CmsEnhancedProduct, AstroProduct>;
+AssertTrue<IfEquals<ProductDiff, never>>();
+
+// #endregion
+
+// #region Config
+
 type CmsConfig = RecursivelyRemoveKeys<
   Awaited<ReturnType<typeof client.queries.config>>["data"]["config"],
   `_${string}`
 >;
 
-type AstroDeliveryMethod = InferEntrySchema<"deliveryMethod">;
-type AstroMaterial = InferEntrySchema<"material">;
-type AstroProduct = InferEntrySchema<"product">;
 type AstroConfig = InferEntrySchema<"config">;
 
-AssertTrue<IfEquals<CmsEnhancedDeliveryMethod, AstroDeliveryMethod>>();
-AssertTrue<IfEquals<CmsEnhancedMaterial, AstroMaterial>>();
+// #endregion
 
 /**
  * Resolve every image reference in a loaded entity to its hashed local `src`.

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -190,7 +190,23 @@ function nodesFrom<TNode>(
  */
 async function optimizeImage(path: string, width: number): Promise<GetImageResult> {
   const optimized = await resolveImage({ src: path, width, format: "webp" });
-  return { ...optimized };
+  return {
+    ...optimized,
+    rawOptions: {
+      ...optimized.rawOptions,
+      src:
+        typeof optimized.rawOptions.src === "string"
+          ? optimized.rawOptions.src
+          : { ...optimized.rawOptions.src },
+    },
+    options: {
+      ...optimized.options,
+      src:
+        typeof optimized.options.src === "string"
+          ? optimized.options.src
+          : { ...optimized.options.src },
+    },
+  };
 }
 
 // Render widths (2x for retina) for images consumed outside `<Image>`.

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -18,7 +18,6 @@ import { resolveImage } from "./assets";
 import {
   AssertTrue,
   type IfEquals,
-  type NullableToUndefined,
   type RecursiveDiff,
   type RecursivelyNullableToUndefined,
   type RecursivelyRemoveKeys,
@@ -32,13 +31,18 @@ import type { GetImageResult } from "astro";
 
 type Image = z.infer<ReturnType<ImageFunction>>;
 
+type CmsOriginalMaterial = Awaited<
+  ReturnType<typeof client.queries.product_materials>
+>["data"]["product_materials"];
+type CmsOriginalProduct = Awaited<ReturnType<typeof client.queries.product>>["data"]["product"];
+type CmsOriginalDeliveryMethod = Awaited<
+  ReturnType<typeof client.queries.delivery_methods>
+>["data"]["delivery_methods"];
+
 // #region DeliveryMethod
 
 type CmsDeliveryMethod = RecursivelyNullableToUndefined<
-  RecursivelyRemoveKeys<
-    Awaited<ReturnType<typeof client.queries.delivery_methods>>["data"]["delivery_methods"],
-    `_${string}`
-  >
+  RecursivelyRemoveKeys<CmsOriginalDeliveryMethod, `_${string}`>
 >;
 interface CmsEnhancedDeliveryMethod extends Omit<CmsDeliveryMethod, "id"> {}
 
@@ -51,10 +55,7 @@ AssertTrue<IfEquals<CmsEnhancedDeliveryMethod, AstroDeliveryMethod>>();
 
 type CmsMaterialColor = NonNullable<NonNullable<CmsMaterial["colors"]>[number]>;
 type CmsMaterial = RecursivelyNullableToUndefined<
-  RecursivelyRemoveKeys<
-    Awaited<ReturnType<typeof client.queries.product_materials>>["data"]["product_materials"],
-    `_${string}`
-  >
+  RecursivelyRemoveKeys<CmsOriginalMaterial, `_${string}`>
 >;
 
 interface CmsEnhancedMaterialColor extends Omit<CmsMaterialColor, "image"> {
@@ -72,10 +73,7 @@ AssertTrue<IfEquals<MaterialDiff, never>>();
 // #endregion
 // #region Product
 type CmsProduct = RecursivelyNullableToUndefined<
-  RecursivelyRemoveKeys<
-    Awaited<ReturnType<typeof client.queries.product>>["data"]["product"],
-    `_${string}`
-  >
+  RecursivelyRemoveKeys<CmsOriginalProduct, `_${string}`>
 >;
 
 type CmsProductImage = NonNullable<NonNullable<CmsProduct["images"]>[number]>;
@@ -118,14 +116,12 @@ interface CmsEnhancedProduct extends Omit<
   | "content"
   | "discount_valid_until"
   | "images"
-  | "image"
   | "materials"
   | "fields"
   | "icon"
 > {
   thumbnail?: GetImageResult | undefined;
   discount_valid_until?: Date | undefined;
-  image?: GetImageResult | undefined;
   icon?: GetImageResult | undefined;
   date?: Date | undefined;
   images?: Array<CmsEnhancedProductImage | undefined> | undefined;
@@ -140,31 +136,23 @@ AssertTrue<IfEquals<ProductDiff, never>>();
 
 // #region Config
 
-type CmsConfig = RecursivelyRemoveKeys<
-  Awaited<ReturnType<typeof client.queries.config>>["data"]["config"],
-  `_${string}`
+type CmsConfig = RecursivelyNullableToUndefined<
+  RecursivelyRemoveKeys<
+    Awaited<ReturnType<typeof client.queries.config>>["data"]["config"],
+    `_${string}`
+  >
 >;
 
-type AstroConfig = InferEntrySchema<"config">;
+type CmsEnhancedConfig = Omit<CmsConfig, "logo" | "footerLogo" | "id"> & {
+  logo?: GetImageResult | undefined;
+  footerLogo?: GetImageResult | undefined;
+};
+
+type AstroConfig = RecursivelyReplaceType<InferEntrySchema<"config">, Image, GetImageResult>;
+type ConfigDiff = RecursiveDiff<CmsEnhancedConfig, AstroConfig>;
+AssertTrue<IfEquals<ConfigDiff, never>>();
 
 // #endregion
-
-/**
- * Resolve every image reference in a loaded entity to its hashed local `src`.
- *
- * Tina image fields and rich-text `img` urls are stored as paths: a local
- * `/src/assets/...` path in `--local` builds, or an absolute Tina Cloud CDN URL
- * (`https://assets.tina.io/.../__file/<path>`) in cloud builds. Left untouched
- * the cloud form is serialized into a client island's props and hot-links to
- * Tina Cloud (see scripts/test/no-tina-cloud-urls.ts).
- *
- * Rather than enumerate every (easily-missed, deeply-nested) image field, we
- * walk the whole value and replace any string that looks like an image
- * reference with the optimized local `src` (`resolveImage` normalizes both
- * forms). Strings that don't resolve to a `src/assets` file are left as-is, so
- * the walk is safe to run over an entire entity.
- */
-const IMAGE_REF = /\.(?:avif|gif|jpe?g|png|svg|webp)$/i;
 
 /**
  * Flatten a Tina `*Connection` query result into a plain array of nodes,
@@ -174,30 +162,6 @@ function nodesFrom<TNode>(
   connection: { edges?: ({ node?: TNode | null } | null)[] | null } | null | undefined
 ): TNode[] {
   return connection?.edges?.flatMap((edge) => (edge?.node ? [edge.node] : [])) ?? [];
-}
-
-function resolveTinaImageRefs<T>(value: T): T {
-  if (typeof value === "string") {
-    if (IMAGE_REF.test(value)) {
-      const resolved = resolveImage(value);
-      if (resolved) {
-        return resolved.src as T;
-      }
-    }
-    return value;
-  }
-  if (Array.isArray(value)) {
-    return (value as unknown[]).map((item) => resolveTinaImageRefs(item)) as T;
-  }
-  if (value !== null && typeof value === "object") {
-    const source = value as Record<string, unknown>;
-    const result: Record<string, unknown> = {};
-    for (const [key, val] of Object.entries(source)) {
-      result[key] = resolveTinaImageRefs(val);
-    }
-    return result as T;
-  }
-  return value;
 }
 
 /**
@@ -227,54 +191,155 @@ const SWATCH_WIDTH = 200; // ~24px swatch (`size-6`) in the order island
 const LOGO_WIDTH = 400; // ~100–200px header logo
 const FOOTER_LOGO_WIDTH = 510; // ~255px footer logo
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-// export const getConfig = async () => {
-//   const result = await requestWithMetadata(client.queries.config({ relativePath: "config.json" }));
-//   const { logo, footerLogo } = result.data.config;
+export const getConfig = async (): Promise<
+  RecursiveRequired<CmsEnhancedConfig, GetImageResult>
+> => {
+  const result = await requestWithMetadata(client.queries.config({ relativePath: "config.json" }));
+  const { logo, footerLogo } = result.data.config;
 
-//   const data = resolveTinaImageRefs(result.data);
-//   // The header/footer render the logos with a plain `<img>` (and the config is
-//   // also serialized into the order island), so neither can go through
-//   // `<Image>`. Optimize them here at build time instead.
-//   if (logo) {
-//     data.config.logo = await optimizeImage(logo, LOGO_WIDTH);
-//   }
-//   if (footerLogo) {
-//     data.config.footerLogo = await optimizeImage(footerLogo, FOOTER_LOGO_WIDTH);
-//   }
+  return {
+    logo: logo ? await optimizeImage(logo, LOGO_WIDTH) : undefined,
+    footerLogo: footerLogo ? await optimizeImage(footerLogo, FOOTER_LOGO_WIDTH) : undefined,
+    blogPageURL: result.data.config.blogPageURL ?? undefined,
+    contactLink: result.data.config.contactLink ?? undefined,
+    copyright: result.data.config.copyright ?? undefined,
+    description: result.data.config.description ?? undefined,
+    ogLocale: result.data.config.ogLocale ?? undefined,
+    pagination: {
+      pagerSize: result.data.config.pagination?.pagerSize ?? undefined,
+    },
+    fabformURL: result.data.config.fabformURL ?? undefined,
+    title: result.data.config.title,
+    titleAddition: result.data.config.titleAddition ?? undefined,
+    titleSeparator: result.data.config.titleSeparator ?? undefined,
+    themeColor: result.data.config.themeColor ?? undefined,
+    social: (result.data.config.social ?? []).map((social) => ({
+      icon: social?.icon ?? undefined,
+      url: social?.url ?? undefined,
+      weight: social?.weight ?? undefined,
+    })),
+    mainMenu: (result.data.config.mainMenu ?? []).map((menu) => ({
+      name: menu?.name ?? undefined,
+      url: menu?.url ?? undefined,
+      weight: menu?.weight ?? undefined,
+    })),
+    sitemapMenu: (result.data.config.sitemapMenu ?? []).map((menu) => ({
+      name: menu?.name ?? undefined,
+      url: menu?.url ?? undefined,
+      weight: menu?.weight ?? undefined,
+    })),
+    address: {
+      phone: result.data.config.address?.phone ?? undefined,
+      email: result.data.config.address?.email ?? undefined,
+      address: result.data.config.address?.address ?? undefined,
+      openingHours: result.data.config.address?.openingHours ?? undefined,
+    },
+    footerContact: {
+      title: result.data.config.footerContact?.title ?? undefined,
+      button: result.data.config.footerContact?.button ?? undefined,
+      topTitle: result.data.config.footerContact?.topTitle ?? undefined,
+    },
+  };
+};
 
-//   return { ...result, data };
-// };
+export const getProducts = async (): Promise<CmsEnhancedProduct[]> => {
+  const response = await client.queries.productConnection();
 
-// export const getProducts = async (): Promise<Required<CmsEnhancedProduct>[]> => {
-//   const response = await client.queries.productConnection();
+  const products = nodesFrom(response.data.productConnection).toSorted((a, b) =>
+    a.title.localeCompare(b.title)
+  );
 
-//   const products = nodesFrom(response.data.productConnection).toSorted((a, b) =>
-//     a.title.localeCompare(b.title)
-//   );
+  const result: RecursiveRequired<CmsEnhancedProduct, GetImageResult | Date>[] = [];
 
-//   const result: CmsEnhancedProduct[] = [];
+  for (const product of products) {
+    result.push({
+      product_id: product.product_id,
+      title: product.title,
+      hidden_in_product_list: product.hidden_in_product_list ?? undefined,
+      can_be_ordered: product.can_be_ordered ?? undefined,
+      categories: product.categories ?? undefined,
+      date: product.date ? new Date(product.date) : undefined,
+      thumbnail: product.thumbnail ? await optimizeImage(product.thumbnail, LOGO_WIDTH) : undefined,
+      shortDescription: product.shortDescription ?? undefined,
+      icon: product.icon ? await optimizeImage(product.icon, LOGO_WIDTH) : undefined,
+      priced_by_length: product.priced_by_length ?? undefined,
+      price: product.price ?? undefined,
+      discount: product.discount ?? undefined,
+      discount_valid_until: product.discount_valid_until
+        ? new Date(product.discount_valid_until)
+        : undefined,
+      images: await Promise.all(
+        (product.images ?? [])
+          .filter((image) => image != null)
+          .map(async (image) => ({
+            image: image.image ? await optimizeImage(image.image, LOGO_WIDTH) : undefined,
+            description: image.description ?? undefined,
+          }))
+      ),
+      materials: {
+        materials: await Promise.all(
+          (product.materials?.materials ?? [])
+            .filter((material) => material != null)
+            .map(async (material) => {
+              const material_path = material.material_path;
+              return {
+                price: material.price ?? undefined,
+                color_count: material.color_count ?? undefined,
+                material_path: await transformMaterial(material_path),
+              };
+            })
+        ),
+        banned_combinations: await Promise.all(
+          (product.materials?.banned_combinations ?? [])
+            .filter((combination) => combination != null)
+            .map(async (combination) => ({
+              materials: await Promise.all(
+                (combination.materials ?? [])
+                  .filter((material) => material != null)
+                  .map(async (material) => ({
+                    material_path: await transformMaterial(material.material_path),
+                  }))
+              ),
+            }))
+        ),
+        material_required_count: product.materials?.material_required_count ?? undefined,
+      },
+      table:
+        product.table
+          ?.filter((row) => row != null)
+          .map((row) => ({
+            description: row.description ?? undefined,
+            title: row.title ?? undefined,
+          })) ?? undefined,
+    });
+  }
 
-//   for (const product of products) {
-//     result.push;
-//   }
+  return result;
+};
 
-//   // Optimize the color swatches before they're serialized into the order island.
-//   await Promise.all(
-//     products.flatMap(
-//       (product) =>
-//         product.materials?.materials?.flatMap((material) =>
-//           (material?.material_path.colors ?? []).map(async (color) => {
-//             if (color?.image) {
-//               color.image = await optimizeImage(color.image, SWATCH_WIDTH);
-//             }
-//           })
-//         ) ?? []
-//     )
-//   );
-
-//   return products.map((product) => resolveTinaImageRefs(product));
-// };
+const transformMaterial = async (
+  material: CmsOriginalMaterial
+): Promise<RecursiveRequired<CmsEnhancedMaterial, GetImageResult>> => {
+  return {
+    material_id: material.material_id,
+    label: material.label,
+    categories: material.categories ?? undefined,
+    shortDescription: material.shortDescription ?? undefined,
+    thumbnail: material.thumbnail ? await optimizeImage(material.thumbnail, LOGO_WIDTH) : undefined,
+    colors: material.colors
+      ? await Promise.all(
+          material.colors
+            .filter((color) => color != null)
+            .map(async (color) => ({
+              color_id: color.color_id,
+              label: color.label,
+              hex: color.hex ?? undefined,
+              image: color.image ? await optimizeImage(color.image, SWATCH_WIDTH) : undefined,
+            }))
+        )
+      : undefined,
+  };
+};
 
 export const getMaterials = async (): Promise<CmsEnhancedMaterial[]> => {
   const response = await client.queries.product_materialsConnection();
@@ -286,37 +351,15 @@ export const getMaterials = async (): Promise<CmsEnhancedMaterial[]> => {
   const result: RecursiveRequired<CmsEnhancedMaterial, GetImageResult>[] = [];
 
   for (const material of materials) {
-    result.push({
-      material_id: material.material_id,
-      label: material.label,
-      categories: material.categories ?? undefined,
-      shortDescription: material.shortDescription ?? undefined,
-      thumbnail: material.thumbnail
-        ? await optimizeImage(material.thumbnail, LOGO_WIDTH)
-        : undefined,
-      colors: material.colors
-        ? await Promise.all(
-            material.colors
-              .filter((color) => color != null)
-              .map(async (color) => ({
-                color_id: color.color_id,
-                label: color.label,
-                hex: color.hex ?? undefined,
-                image: color.image
-                  ? await optimizeImage(color.image, SWATCH_WIDTH)
-                  : undefined,
-              }))
-          )
-        : undefined,
-    });
+    result.push(await transformMaterial(material));
   }
 
   return result;
 };
 
-// // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-// export const getDeliveryMethods = async () => {
-//   const result = await client.queries.delivery_methodsConnection();
+export const getDeliveryMethods = async (): Promise<CmsEnhancedDeliveryMethod[]> => {
+  const result = await client.queries.delivery_methodsConnection();
 
-//   return nodesFrom(result.data.delivery_methodsConnection);
-// };
+  const nodes = nodesFrom(result.data.delivery_methodsConnection);
+  return nodes;
+};

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -59,11 +59,11 @@ type CmsMaterial = RecursivelyNullableToUndefined<
 >;
 
 interface CmsEnhancedMaterialColor extends Omit<CmsMaterialColor, "image"> {
-  image?: GetImageResult | undefined;
+  image?: GetImageResult | undefined | null;
 }
 interface CmsEnhancedMaterial extends Omit<CmsMaterial, "id" | "thumbnail" | "colors" | "content"> {
-  thumbnail?: GetImageResult | undefined;
-  colors?: Array<CmsEnhancedMaterialColor> | undefined;
+  thumbnail?: GetImageResult | undefined | null;
+  colors?: Array<CmsEnhancedMaterialColor> | undefined | null;
 }
 
 type AstroMaterial = RecursivelyReplaceType<InferEntrySchema<"material">, Image, GetImageResult>;
@@ -84,7 +84,7 @@ type CmsProductMaterialsBannedCombination = NonNullable<
 >;
 
 interface CmsEnhancedProductImage extends Omit<CmsProductImage, "image"> {
-  image?: GetImageResult | undefined;
+  image?: GetImageResult | undefined | null;
 }
 
 interface CmsEnhancedProductMaterial extends Omit<
@@ -98,15 +98,19 @@ interface CmsEnhancedProductMaterialsBannedCombination extends Omit<
   NonNullable<CmsProductMaterialsBannedCombination>,
   "materials"
 > {
-  materials?: Array<{ material_path?: CmsEnhancedMaterial | undefined } | undefined> | undefined;
+  materials?:
+    | Array<{ material_path?: CmsEnhancedMaterial | undefined | null } | undefined | null>
+    | undefined
+    | null;
 }
 
 interface CmsEnhancedProductMaterials extends Omit<
   CmsProductMaterials,
   "materials" | "banned_combinations"
 > {
-  materials?: Array<CmsEnhancedProductMaterial | undefined> | undefined;
-  banned_combinations?: Array<CmsEnhancedProductMaterialsBannedCombination | undefined> | undefined;
+  materials?: Array<CmsEnhancedProductMaterial | undefined | null> | undefined | null;
+  banned_combinations?:
+    Array<CmsEnhancedProductMaterialsBannedCombination | undefined | null> | undefined | null;
 }
 interface CmsEnhancedProduct extends Omit<
   CmsProduct,
@@ -120,12 +124,12 @@ interface CmsEnhancedProduct extends Omit<
   | "fields"
   | "icon"
 > {
-  thumbnail?: GetImageResult | undefined;
-  discount_valid_until?: Date | undefined;
-  icon?: GetImageResult | undefined;
-  date?: Date | undefined;
-  images?: Array<CmsEnhancedProductImage | undefined> | undefined;
-  materials?: CmsEnhancedProductMaterials | undefined;
+  thumbnail?: GetImageResult | undefined | null;
+  discount_valid_until?: Date | undefined | null;
+  icon?: GetImageResult | undefined | null;
+  date?: Date | undefined | null;
+  images?: Array<CmsEnhancedProductImage | undefined | null> | undefined | null;
+  materials?: CmsEnhancedProductMaterials | undefined | null;
 }
 
 type AstroProduct = RecursivelyReplaceType<InferEntrySchema<"product">, Image, GetImageResult>;
@@ -144,8 +148,8 @@ type CmsConfig = RecursivelyNullableToUndefined<
 >;
 
 type CmsEnhancedConfig = Omit<CmsConfig, "logo" | "footerLogo" | "id"> & {
-  logo?: GetImageResult | undefined;
-  footerLogo?: GetImageResult | undefined;
+  logo?: GetImageResult | undefined | null;
+  footerLogo?: GetImageResult | undefined | null;
 };
 
 type AstroConfig = RecursivelyReplaceType<InferEntrySchema<"config">, Image, GetImageResult>;
@@ -180,7 +184,7 @@ function nodesFrom<TNode>(
 async function optimizeImage(path: string, width: number): Promise<GetImageResult> {
   const meta = resolveImage(path);
   if (!meta) {
-    return { src: path };
+    return { src: path, options: { width, format: "webp" } };
   }
   const optimized = await getImage({ src: meta, width, format: "webp" });
   return optimized;

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -22,10 +22,13 @@ import {
   type RecursiveDiff,
   type RecursivelyNullableToUndefined,
   type RecursivelyRemoveKeys,
+  type RecursivelyReplaceType,
+  type RecursiveRequired,
 } from "./typeUtils";
 import type { InferEntrySchema } from "astro:content";
 import type { ImageFunction } from "astro/content/config";
 import type { z } from "astro/zod";
+import type { GetImageResult } from "astro";
 
 type Image = z.infer<ReturnType<ImageFunction>>;
 
@@ -55,14 +58,14 @@ type CmsMaterial = RecursivelyNullableToUndefined<
 >;
 
 interface CmsEnhancedMaterialColor extends Omit<CmsMaterialColor, "image"> {
-  image?: Image | undefined;
+  image?: GetImageResult | undefined;
 }
 interface CmsEnhancedMaterial extends Omit<CmsMaterial, "id" | "thumbnail" | "colors" | "content"> {
-  thumbnail?: Image | undefined;
+  thumbnail?: GetImageResult | undefined;
   colors?: Array<CmsEnhancedMaterialColor> | undefined;
 }
 
-type AstroMaterial = InferEntrySchema<"material">;
+type AstroMaterial = RecursivelyReplaceType<InferEntrySchema<"material">, Image, GetImageResult>;
 type MaterialDiff = RecursiveDiff<CmsEnhancedMaterial, AstroMaterial>;
 AssertTrue<IfEquals<MaterialDiff, never>>();
 
@@ -83,7 +86,7 @@ type CmsProductMaterialsBannedCombination = NonNullable<
 >;
 
 interface CmsEnhancedProductImage extends Omit<CmsProductImage, "image"> {
-  image?: Image | undefined;
+  image?: GetImageResult | undefined;
 }
 
 interface CmsEnhancedProductMaterial extends Omit<
@@ -120,16 +123,16 @@ interface CmsEnhancedProduct extends Omit<
   | "fields"
   | "icon"
 > {
-  thumbnail?: Image | undefined;
+  thumbnail?: GetImageResult | undefined;
   discount_valid_until?: Date | undefined;
-  image?: Image | undefined;
-  icon?: Image | undefined;
+  image?: GetImageResult | undefined;
+  icon?: GetImageResult | undefined;
   date?: Date | undefined;
   images?: Array<CmsEnhancedProductImage | undefined> | undefined;
   materials?: CmsEnhancedProductMaterials | undefined;
 }
 
-type AstroProduct = InferEntrySchema<"product">;
+type AstroProduct = RecursivelyReplaceType<InferEntrySchema<"product">, Image, GetImageResult>;
 type ProductDiff = RecursiveDiff<CmsEnhancedProduct, AstroProduct>;
 AssertTrue<IfEquals<ProductDiff, never>>();
 
@@ -210,13 +213,13 @@ function resolveTinaImageRefs<T>(value: T): T {
  * path when it can't resolve to a local asset (e.g. SVGs the pipeline passes
  * through, or unknown references).
  */
-async function optimizeImage(path: string, width: number): Promise<string> {
+async function optimizeImage(path: string, width: number): Promise<GetImageResult> {
   const meta = resolveImage(path);
   if (!meta) {
-    return path;
+    return { src: path };
   }
   const optimized = await getImage({ src: meta, width, format: "webp" });
-  return optimized.src;
+  return optimized;
 }
 
 // Render widths (2x for retina) for images consumed outside `<Image>`.
@@ -225,61 +228,95 @@ const LOGO_WIDTH = 400; // ~100–200px header logo
 const FOOTER_LOGO_WIDTH = 510; // ~255px footer logo
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export const getConfig = async () => {
-  const result = await requestWithMetadata(client.queries.config({ relativePath: "config.json" }));
-  const { logo, footerLogo } = result.data.config;
+// export const getConfig = async () => {
+//   const result = await requestWithMetadata(client.queries.config({ relativePath: "config.json" }));
+//   const { logo, footerLogo } = result.data.config;
 
-  const data = resolveTinaImageRefs(result.data);
-  // The header/footer render the logos with a plain `<img>` (and the config is
-  // also serialized into the order island), so neither can go through
-  // `<Image>`. Optimize them here at build time instead.
-  if (logo) {
-    data.config.logo = await optimizeImage(logo, LOGO_WIDTH);
-  }
-  if (footerLogo) {
-    data.config.footerLogo = await optimizeImage(footerLogo, FOOTER_LOGO_WIDTH);
-  }
+//   const data = resolveTinaImageRefs(result.data);
+//   // The header/footer render the logos with a plain `<img>` (and the config is
+//   // also serialized into the order island), so neither can go through
+//   // `<Image>`. Optimize them here at build time instead.
+//   if (logo) {
+//     data.config.logo = await optimizeImage(logo, LOGO_WIDTH);
+//   }
+//   if (footerLogo) {
+//     data.config.footerLogo = await optimizeImage(footerLogo, FOOTER_LOGO_WIDTH);
+//   }
 
-  return { ...result, data };
-};
+//   return { ...result, data };
+// };
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export const getProducts = async () => {
-  const result = await client.queries.productConnection();
+// export const getProducts = async (): Promise<Required<CmsEnhancedProduct>[]> => {
+//   const response = await client.queries.productConnection();
 
-  const products = nodesFrom(result.data.productConnection).toSorted((a, b) =>
-    a.title.localeCompare(b.title)
+//   const products = nodesFrom(response.data.productConnection).toSorted((a, b) =>
+//     a.title.localeCompare(b.title)
+//   );
+
+//   const result: CmsEnhancedProduct[] = [];
+
+//   for (const product of products) {
+//     result.push;
+//   }
+
+//   // Optimize the color swatches before they're serialized into the order island.
+//   await Promise.all(
+//     products.flatMap(
+//       (product) =>
+//         product.materials?.materials?.flatMap((material) =>
+//           (material?.material_path.colors ?? []).map(async (color) => {
+//             if (color?.image) {
+//               color.image = await optimizeImage(color.image, SWATCH_WIDTH);
+//             }
+//           })
+//         ) ?? []
+//     )
+//   );
+
+//   return products.map((product) => resolveTinaImageRefs(product));
+// };
+
+export const getMaterials = async (): Promise<CmsEnhancedMaterial[]> => {
+  const response = await client.queries.product_materialsConnection();
+
+  const materials = nodesFrom(response.data.product_materialsConnection).toSorted((a, b) =>
+    a.label.localeCompare(b.label)
   );
 
-  // Optimize the color swatches before they're serialized into the order island.
-  await Promise.all(
-    products.flatMap(
-      (product) =>
-        product.materials?.materials?.flatMap((material) =>
-          (material?.material_path.colors ?? []).map(async (color) => {
-            if (color?.image) {
-              color.image = await optimizeImage(color.image, SWATCH_WIDTH);
-            }
-          })
-        ) ?? []
-    )
-  );
+  const result: RecursiveRequired<CmsEnhancedMaterial, GetImageResult>[] = [];
 
-  return products.map((product) => resolveTinaImageRefs(product));
+  for (const material of materials) {
+    result.push({
+      material_id: material.material_id,
+      label: material.label,
+      categories: material.categories ?? undefined,
+      shortDescription: material.shortDescription ?? undefined,
+      thumbnail: material.thumbnail
+        ? await optimizeImage(material.thumbnail, LOGO_WIDTH)
+        : undefined,
+      colors: material.colors
+        ? await Promise.all(
+            material.colors
+              .filter((color) => color != null)
+              .map(async (color) => ({
+                color_id: color.color_id,
+                label: color.label,
+                hex: color.hex ?? undefined,
+                image: color.image
+                  ? await optimizeImage(color.image, SWATCH_WIDTH)
+                  : undefined,
+              }))
+          )
+        : undefined,
+    });
+  }
+
+  return result;
 };
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export const getMaterials = async () => {
-  const result = await client.queries.product_materialsConnection();
+// // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+// export const getDeliveryMethods = async () => {
+//   const result = await client.queries.delivery_methodsConnection();
 
-  return nodesFrom(result.data.product_materialsConnection)
-    .toSorted((a, b) => a.label.localeCompare(b.label))
-    .map((material) => resolveTinaImageRefs(material));
-};
-
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export const getDeliveryMethods = async () => {
-  const result = await client.queries.delivery_methodsConnection();
-
-  return nodesFrom(result.data.delivery_methodsConnection);
-};
+//   return nodesFrom(result.data.delivery_methodsConnection);
+// };

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -11,10 +11,8 @@
  * is the source of truth; regen with `tinacms dev` and everything
  * downstream updates.
  */
-import { getImage } from "astro:assets";
 import { requestWithMetadata } from "@tinacms/astro/data";
 import client from "../../tina/__generated__/client";
-import { resolveImage } from "./assets";
 import {
   AssertTrue,
   type IfEquals,
@@ -29,6 +27,7 @@ import type { InferEntrySchema } from "astro:content";
 import type { ImageFunction } from "astro/content/config";
 import type { z } from "astro/zod";
 import type { GetImageResult } from "astro";
+import { resolveImage } from "./assets";
 
 type Image = z.infer<ReturnType<ImageFunction>>;
 
@@ -190,11 +189,7 @@ function nodesFrom<TNode>(
  * through, or unknown references).
  */
 async function optimizeImage(path: string, width: number): Promise<GetImageResult> {
-  const meta = resolveImage(path);
-  if (!meta) {
-    return { src: path, options: { width, format: "webp" } };
-  }
-  const optimized = await getImage({ src: meta, width, format: "webp" });
+  const optimized = await resolveImage({ src: path, width, format: "webp" });
   return { ...optimized };
 }
 

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -189,7 +189,7 @@ function nodesFrom<TNode>(
  * through, or unknown references).
  */
 async function optimizeImage(path: string, width: number): Promise<GetImageResult> {
-  const optimized = await resolveImage({ src: path, width, format: "webp" });
+  const optimized = await resolveImage({ src: path, width });
   return {
     ...optimized,
     rawOptions: {

--- a/src/lib/orderSubmit.ts
+++ b/src/lib/orderSubmit.ts
@@ -4,7 +4,7 @@
  */
 import { calculatePriceForItem } from "@/lib/priceUtils";
 import type { IProduct, Field, CmsProductMaterial, ProductMaterialValue } from "./types.svelte";
-import type { CmsDeliveryMethod } from "./data";
+import type { CmsEnhancedDeliveryMethod } from "./data";
 
 const WEB3FORMS_ENDPOINT = "https://api.web3forms.com/submit";
 
@@ -12,14 +12,14 @@ export interface OrderDetails {
   name: string;
   email: string;
   phone: string;
-  deliveryMethod: CmsDeliveryMethod;
+  deliveryMethod: CmsEnhancedDeliveryMethod;
   products: IProduct[];
 }
 
 /** Sum of every product's total plus delivery, and whether any price is partial. */
 export function calculateOrderTotal(
   products: IProduct[],
-  deliveryMethod: CmsDeliveryMethod
+  deliveryMethod: CmsEnhancedDeliveryMethod
 ): { total: number; indeterminate: boolean } {
   const prices = products.map((p) => calculatePriceForItem(p));
   return {
@@ -53,7 +53,7 @@ function formatMaterialLine(
   const color = mv?.custom_color
     ? `Egyedi szín: ${mv.custom_color}`
     : (mv?.colors
-        .map((x) => material?.material_path.colors?.find((c) => c?.color_id === x)?.label ?? x)
+        .map((x) => material?.material_path.colors?.find((c) => c.color_id === x)?.label ?? x)
         .join(", ") ?? "");
   return `    - ${név} (${color})`;
 }

--- a/src/lib/typeUtils.ts
+++ b/src/lib/typeUtils.ts
@@ -43,3 +43,90 @@ export type RecursivelyNullableToUndefined<T> =
           [P in keyof T]: RecursivelyNullableToUndefined<NullableToUndefined<T[P]>>;
         }
       : NullableToUndefined<T>;
+
+/** Marker used by {@link RecursiveDiff} for a property that exists on one side but not the other. */
+type Missing = "(missing)";
+
+/** Indexed access that falls back to {@link Missing} when the key is absent. */
+type Prop<T, K extends PropertyKey> = K extends keyof T ? T[K] : Missing;
+
+/**
+ * A single-property slice of `T`, so equality checks keep the optional (`?`)
+ * modifier — a bare indexed access (`T[K]`) would drop it and hide the very
+ * difference we're trying to surface.
+ */
+type PickProp<T, K extends PropertyKey> = K extends keyof T ? Pick<T, K> : Record<never, never>;
+
+/** One flattened diff: a dotted `path` and the `{ left; right }` found there. */
+interface DiffEntry {
+  path: string;
+  diff: unknown;
+}
+
+/** Join a path prefix and a key with `.` (no leading dot at the root). */
+type JoinPath<Prefix extends string, K extends PropertyKey> = Prefix extends ""
+  ? K & string
+  : `${Prefix}.${K & string}`;
+
+/**
+ * Walk `T` vs `U` and emit a union of {@link DiffEntry} — one per point where
+ * they diverge — with `path` accumulated in `a.b.c` notation (and `[number]`
+ * for array elements).
+ *
+ * Equality is tested with {@link IfEquals} (identity) at every level, so pairs
+ * that are mutually assignable but not identical (an optional modifier, an
+ * added `undefined`, …) still surface. A property present on only one side
+ * shows `"(missing)"` for the absent side; a property that differs solely by
+ * optionality reports its single-key {@link Pick} slice so the `?` is visible.
+ *
+ * `undefined` / `null` are stripped ({@link NonNullable}) before the structural
+ * checks so nullable objects (`X | undefined`) are still recursed into. When
+ * that strip is the *only* difference, the node is reported as a leaf showing
+ * both nullable forms.
+ */
+type DiffEntries<T, U, Prefix extends string = ""> =
+  IfEquals<T, U> extends true
+    ? never
+    : NonNullable<T> extends infer NT
+      ? NonNullable<U> extends infer NU
+        ? IfEquals<NT, NU> extends true
+          ? { path: Prefix; diff: { left: T; right: U } }
+          : [NT, NU] extends [ReadonlyArray<infer TE>, ReadonlyArray<infer UE>]
+            ? DiffEntries<TE, UE, `${Prefix}[number]`>
+            : [NT, NU] extends [object, object]
+              ? {
+                  [K in keyof NT | keyof NU]: IfEquals<
+                    PickProp<NT, K>,
+                    PickProp<NU, K>
+                  > extends true
+                    ? never
+                    : IfEquals<Prop<NT, K>, Prop<NU, K>> extends true
+                      ? {
+                          path: JoinPath<Prefix, K>;
+                          diff: { left: PickProp<NT, K>; right: PickProp<NU, K> };
+                        }
+                      : DiffEntries<Prop<NT, K>, Prop<NU, K>, JoinPath<Prefix, K>>;
+                }[keyof NT | keyof NU]
+              : { path: Prefix; diff: { left: T; right: U } }
+        : never
+      : never;
+
+/**
+ * Recursive structural difference between two types, flattened into a single
+ * object whose keys are dotted paths (`a.b.c`, `list[number].id`) pointing at
+ * every spot where `T` and `U` diverge — so nested mismatches are visible at a
+ * glance instead of being buried in a nested shape.
+ *
+ * Each value is `{ left: <T side>; right: <U side> }`. A property missing on
+ * one side shows `"(missing)"`; a property differing only by optionality shows
+ * its single-key slice (`{ k?: V }` vs `{ k: V }`). Fully-equal types resolve
+ * to `never`.
+ *
+ * Hover the resulting alias (e.g. `ProductDiff`) to read the difference.
+ */
+export type RecursiveDiff<T, U> =
+  IfEquals<T, U> extends true
+    ? never
+    : DiffEntries<T, U> extends infer E extends DiffEntry
+      ? { [P in E["path"]]: Extract<E, { path: P }>["diff"] }
+      : never;

--- a/src/lib/typeUtils.ts
+++ b/src/lib/typeUtils.ts
@@ -9,3 +9,17 @@ export type ExtractValues<T, U> = {
 export type Serialised<T> = {
   [K in keyof T]: T[K] extends { serialise: () => infer R } ? R : Serialised<T[K]>;
 };
+
+/** Returns `true` if T and U matches, return `false` otherwise */
+export type IfEquals<T, U, Y = true, N = false> =
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
+  (<G>() => G extends T ? 1 : 2) extends <G>() => G extends U ? 1 : 2 ? Y : N;
+
+/**
+ * This is for build-time type-checking, will be stripped by tree-shaking because it does nothing
+ *
+ * @example
+ * AssertTrue<IfEquals<MyType, MyOtherType>>();
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-unnecessary-type-parameters
+export function AssertTrue<T extends true>(): void {}

--- a/src/lib/typeUtils.ts
+++ b/src/lib/typeUtils.ts
@@ -33,7 +33,7 @@ export type RecursivelyRemoveKeys<T, K extends string> =
         }
       : T;
 
-export type NullableToUndefined<T> = T extends null ? Exclude<T, null> | undefined : T;
+export type NullableToUndefined<T> = T extends null ? T | undefined : T;
 
 export type RecursivelyNullableToUndefined<T> =
   T extends Array<infer U>
@@ -122,13 +122,21 @@ type DiffEntries<T, U, Prefix extends string = ""> =
  * its single-key slice (`{ k?: V }` vs `{ k: V }`). Fully-equal types resolve
  * to `never`.
  *
+ * Types that are mutually assignable but not identical in a way `DiffEntries`
+ * cannot localise to a leaf (e.g. the `exactOptionalPropertyTypes` distinction
+ * between `k?: V` and `k?: V | undefined`, which collapses under the indexed
+ * access used while recursing) also resolve to `never` rather than an empty
+ * `{}` — so the result is always either `never` or a populated diff.
+ *
  * Hover the resulting alias (e.g. `ProductDiff`) to read the difference.
  */
 export type RecursiveDiff<T, U> =
   IfEquals<T, U> extends true
     ? never
     : DiffEntries<T, U> extends infer E extends DiffEntry
-      ? { [P in E["path"]]: Extract<E, { path: P }>["diff"] }
+      ? [E] extends [never]
+        ? never
+        : { [P in E["path"]]: Extract<E, { path: P }>["diff"] }
       : never;
 
 /**

--- a/src/lib/typeUtils.ts
+++ b/src/lib/typeUtils.ts
@@ -130,3 +130,26 @@ export type RecursiveDiff<T, U> =
     : DiffEntries<T, U> extends infer E extends DiffEntry
       ? { [P in E["path"]]: Extract<E, { path: P }>["diff"] }
       : never;
+
+/**
+ * Recursively make every property of `T` required (removing `?` at every
+ * depth). Types assignable to `Stop` are treated as leaves: they are left
+ * untouched and not descended into, so their own optional members stay
+ * optional. The `Stop` check distributes over unions, so a `Stop | undefined`
+ * member is preserved as-is while the rest of the value is still made required.
+ */
+export type RecursiveRequired<T, Stop = never> = T extends Stop
+  ? T
+  : T extends Array<infer U>
+    ? Array<RecursiveRequired<U, Stop>>
+    : T extends object
+      ? { [K in keyof T]-?: RecursiveRequired<T[K], Stop> }
+      : T;
+
+export type RecursivelyReplaceType<T, From, To> = T extends From
+  ? To
+  : T extends Array<infer U>
+    ? Array<RecursivelyReplaceType<U, From, To>>
+    : T extends object
+      ? { [K in keyof T]: RecursivelyReplaceType<T[K], From, To> }
+      : T;

--- a/src/lib/typeUtils.ts
+++ b/src/lib/typeUtils.ts
@@ -161,3 +161,26 @@ export type RecursivelyReplaceType<T, From, To> = T extends From
     : T extends object
       ? { [K in keyof T]: RecursivelyReplaceType<T[K], From, To> }
       : T;
+
+/**
+ * Recursively replace the value type of every property named `K` with `To`,
+ * preserving whatever `null` / `undefined` the original value allowed (so an
+ * optional / nullable `K` stays optional / nullable). Property modifiers
+ * (`?`, `readonly`) are kept because the mapping is homomorphic.
+ *
+ * Used to graft a resolved reference type onto a schema where the same field is
+ * only an unresolved key: e.g. the Astro content collection stores
+ * `material_path` as the raw `string` path from the `.md` frontmatter, while
+ * Tina resolves it to a full material — this rewrites those `string`s to the
+ * resolved shape so the two derived types line up.
+ */
+export type RecursivelyReplaceKeyType<T, K extends PropertyKey, To> =
+  T extends Array<infer U>
+    ? Array<RecursivelyReplaceKeyType<U, K, To>>
+    : T extends object
+      ? {
+          [P in keyof T]: P extends K
+            ? To | Extract<T[P], null | undefined>
+            : RecursivelyReplaceKeyType<T[P], K, To>;
+        }
+      : T;

--- a/src/lib/typeUtils.ts
+++ b/src/lib/typeUtils.ts
@@ -23,3 +23,23 @@ export type IfEquals<T, U, Y = true, N = false> =
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-unnecessary-type-parameters
 export function AssertTrue<T extends true>(): void {}
+
+export type RecursivelyRemoveKeys<T, K extends string> =
+  T extends Array<infer U>
+    ? Array<RecursivelyRemoveKeys<U, K>>
+    : T extends object
+      ? {
+          [P in keyof T as P extends K ? never : P]: RecursivelyRemoveKeys<T[P], K>;
+        }
+      : T;
+
+export type NullableToUndefined<T> = T extends null ? Exclude<T, null> | undefined : T;
+
+export type RecursivelyNullableToUndefined<T> =
+  T extends Array<infer U>
+    ? Array<RecursivelyNullableToUndefined<U>>
+    : T extends object
+      ? {
+          [P in keyof T]: RecursivelyNullableToUndefined<NullableToUndefined<T[P]>>;
+        }
+      : NullableToUndefined<T>;

--- a/src/lib/types.svelte.ts
+++ b/src/lib/types.svelte.ts
@@ -1,4 +1,4 @@
-import type { CmsProduct } from "./data";
+import type { CmsEnhancedProduct } from "./data";
 export interface ValueWithError {
   value: string;
   is_custom?: boolean;
@@ -12,8 +12,8 @@ export interface ProductMaterialValue {
   error?: string | undefined;
 }
 
-export type CmsField = NonNullable<CmsProduct["fields"]>[number];
-export type CmsProductMaterials = NonNullable<CmsProduct["materials"]>;
+export type CmsField = NonNullable<CmsEnhancedProduct["fields"]>[number];
+export type CmsProductMaterials = NonNullable<CmsEnhancedProduct["materials"]>;
 export type CmsProductMaterial = NonNullable<CmsProductMaterials["materials"]>[number];
 
 export type Field = CmsField & { value?: ValueWithError | undefined };
@@ -26,7 +26,7 @@ export type ProductMaterials = Omit<
   materials: CmsProductMaterial[];
 };
 
-export interface IProduct extends Omit<CmsProduct, "materials" | "fields"> {
+export interface IProduct extends Omit<CmsEnhancedProduct, "materials" | "fields"> {
   uuid: string;
   count: number;
   materials: ProductMaterials;

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -8,8 +8,8 @@ import {
   getConfig,
   getDeliveryMethods,
   getProducts,
-  type CmsDeliveryMethod,
-  type CmsProduct,
+  type CmsEnhancedProduct,
+  type CmsEnhancedDeliveryMethod,
 } from "../lib/data";
 import locationIcon from "../assets/images/contact/location.svg";
 import phoneIcon from "../assets/images/contact/phone.svg";
@@ -20,7 +20,7 @@ const [entry] = await getCollection("contact");
 const { Content } = await render(entry);
 const { title, breadcrumb } = entry.data;
 
-const config = (await getConfig()).data.config;
+const config = await getConfig();
 const address = config.address ?? null;
 const social = [...(config.social ?? [])]
   .filter((s): s is NonNullable<typeof s> => !!s && !!s.icon)
@@ -36,7 +36,7 @@ const deliveryMethods = await getDeliveryMethods();
   <section class="py-12.5">
     <div class="not-prose container">
       <OrderForm
-        products={products.reduce<Record<string, CmsProduct>>((acc, p) => {
+        products={products.reduce<Record<string, CmsEnhancedProduct>>((acc, p) => {
           if (!p.can_be_ordered) {
             return acc;
           }
@@ -44,10 +44,13 @@ const deliveryMethods = await getDeliveryMethods();
           acc[p.product_id] = p;
           return acc;
         }, {})}
-        deliveryMethods={deliveryMethods.reduce<Record<string, CmsDeliveryMethod>>((acc, d) => {
-          acc[d.delivery_name] = d;
-          return acc;
-        }, {})}
+        deliveryMethods={deliveryMethods.reduce<Record<string, CmsEnhancedDeliveryMethod>>(
+          (acc, d) => {
+            acc[d.delivery_name] = d;
+            return acc;
+          },
+          {}
+        )}
         config={config}
         client:load
       />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,7 +7,7 @@ import Blog from "../components/blocks/Blog.astro";
 import About from "../components/blocks/About.astro";
 import { getConfig } from "../lib/data";
 
-const config = (await getConfig()).data.config;
+const config = await getConfig();
 ---
 
 <Base

--- a/src/pages/material/[...page].astro
+++ b/src/pages/material/[...page].astro
@@ -9,7 +9,7 @@ import Pagination from "../../components/ui/Pagination.astro";
 export const getStaticPaths = (async () => {
   const PAGE_SIZE = 6;
   const materials = (await getCollection("material")).toSorted((a, b) =>
-    (a.data.label ?? a.data.title).localeCompare(b.data.label ?? b.data.title)
+    a.data.label.localeCompare(b.data.label)
   );
 
   const lastPage = Math.max(1, Math.ceil(materials.length / PAGE_SIZE));
@@ -39,9 +39,9 @@ const { items, currentPage, lastPage } = Astro.props;
           items.map((material) => (
             <ProductCard
               href={`/material/${material.id}/`}
-              title={material.data.label ?? material.data.title}
-              image={material.data.thumbnail}
-              category={material.data.categories}
+              title={material.data.label}
+              image={material.data.thumbnail ?? undefined}
+              category={material.data.categories ?? undefined}
             />
           ))
         }

--- a/src/pages/material/[id].astro
+++ b/src/pages/material/[id].astro
@@ -8,7 +8,7 @@ import FloatingShapes from "../../components/ui/FloatingShapes.astro";
 
 export const getStaticPaths = (async () => {
   const materials = (await getCollection("material")).toSorted((a, b) =>
-    (a.data.label ?? a.data.title).localeCompare(b.data.label ?? b.data.title)
+    a.data.label.localeCompare(b.data.label)
   );
 
   return materials.map((material, i) => ({
@@ -24,8 +24,8 @@ export const getStaticPaths = (async () => {
 const { material, prev, next } = Astro.props;
 const { Content } = await render(material);
 
-const { title, label, shortDescription } = material.data;
-const heading = label ?? title;
+const { label, shortDescription } = material.data;
+const heading = label;
 
 const thumb = material.data.thumbnail;
 const colors = (material.data.colors ?? []).map((color) => ({
@@ -134,7 +134,7 @@ const shareLinks = [
                 <span class="text-left">
                   <span class="text-body block text-sm">Előző</span>
                   <span class="font-heading text-dark group-hover:text-sand-300 block text-xl">
-                    {prev.data.label ?? prev.data.title}
+                    {prev.data.label}
                   </span>
                 </span>
               </a>
@@ -166,7 +166,7 @@ const shareLinks = [
                 <span class="text-right">
                   <span class="text-body block text-sm">Következő</span>
                   <span class="font-heading text-dark group-hover:text-sand-300 block text-xl">
-                    {next.data.label ?? next.data.title}
+                    {next.data.label}
                   </span>
                 </span>
                 <span class="text-dark ml-3 leading-none">

--- a/src/pages/product/[...page].astro
+++ b/src/pages/product/[...page].astro
@@ -40,8 +40,8 @@ const { items, currentPage, lastPage } = Astro.props;
             <ProductCard
               href={`/product/${product.id}/`}
               title={product.data.title}
-              image={product.data.thumbnail}
-              category={product.data.categories}
+              image={product.data.thumbnail ?? undefined}
+              category={product.data.categories ?? undefined}
               square
             />
           ))

--- a/src/pages/product/[id].astro
+++ b/src/pages/product/[id].astro
@@ -38,9 +38,9 @@ if (thumb) {
   gallery.push({ src: thumb, alt: title });
 }
 for (const entry of product.data.images ?? []) {
-  const img = entry.image;
+  const img = entry?.image;
   if (img) {
-    gallery.push({ src: img, alt: title, description: entry.description });
+    gallery.push({ src: img, alt: title, description: entry?.description ?? undefined });
   }
 }
 
@@ -78,14 +78,16 @@ const shareLinks = [
         </div>
 
         {
-          table.length > 0 && (
+          table && table.length > 0 && (
             <div class="bg-accent mt-12.5 mb-2.5 flex flex-col flex-wrap justify-center rounded-[20px] px-0 py-7.5 text-white sm:mt-17.5 sm:mb-12.5 sm:flex-row sm:px-5">
-              {table.map((item) => (
-                <div class="w-full py-0 not-last:mb-7.5 sm:w-1/2 sm:py-2.5 sm:not-last:mb-0 md:w-1/3">
-                  <h5 class="text-h5 text-light">{item.title}</h5>
-                  <p class="m-0">{item.description}</p>
-                </div>
-              ))}
+              {table
+                .filter((item) => item != null)
+                .map((item) => (
+                  <div class="w-full py-0 not-last:mb-7.5 sm:w-1/2 sm:py-2.5 sm:not-last:mb-0 md:w-1/3">
+                    <h5 class="text-h5 text-light">{item.title}</h5>
+                    <p class="m-0">{item.description}</p>
+                  </div>
+                ))}
             </div>
           )
         }

--- a/tests/hydration.spec.ts
+++ b/tests/hydration.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type ConsoleMessage } from "@playwright/test";
+import { test, expect, type ConsoleMessage, type Locator } from "@playwright/test";
 
 /**
  * Routes that mount a Svelte client island (`<astro-island>`). The order form on
@@ -15,6 +15,170 @@ const ISLAND_ROUTES = ["/contact"];
  * logs hydration mismatches.
  */
 const HYDRATION_ERROR = /\[astro-island\]|\[hydrate\]|hydration|is not iterable/i;
+
+/**
+ * ---------------------------------------------------------------------------
+ * Prop-revival diagnostics
+ * ---------------------------------------------------------------------------
+ * Astro serializes island props to the `props` attribute as nested
+ * `[type, value]` tuples and revives them client-side (see
+ * node_modules/astro/dist/runtime/server/astro-island.js). The reviver does
+ * `const [type, value] = raw` on every node, so if serialization ever puts a
+ * *non-array* into a tuple slot, that destructuring throws
+ * `"<type> is not iterable"` and the whole island silently fails to hydrate —
+ * exactly the failure we keep hitting on the order form.
+ *
+ * The walker below mirrors astro's `reviveObject`/`reviveTuple`/`reviveArray`
+ * but, instead of throwing on the first malformed node, records the JSON path
+ * of every offending value so the test can print *which* prop broke.
+ */
+
+/** PROP_TYPE ids whose payload is an array the reviver iterates (`raw.map`): */
+/**  1 = Array/JSON, 4 = Map entries, 5 = Set entries (astro serialize.ts). */
+const ARRAY_PAYLOAD_TYPES = new Set([1, 4, 5]);
+/** Every PROP_TYPE id astro knows how to revive (0–11). */
+const KNOWN_PROP_TYPES = new Set([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+
+interface NonRevivableProp {
+  path: string;
+  reason: string;
+  preview: string;
+}
+
+/**
+ * Short, safe, one-line preview of a serialized value. Inputs always come from
+ * `JSON.parse`, so `JSON.stringify` can't return `undefined` or throw here.
+ */
+function previewValue(value: unknown): string {
+  const text = typeof value === "string" ? value : JSON.stringify(value);
+  return text.length > 200 ? `${text.slice(0, 200)}…` : text;
+}
+
+/**
+ * Walk a serialized `props` attribute the same way astro-island revives it and
+ * collect every path where revival would throw (a tuple slot that isn't an
+ * array, or an array-payload type whose payload isn't an array).
+ */
+function collectNonRevivableProps(propsAttr: string | null): NonRevivableProp[] {
+  if (!propsAttr) {
+    return [];
+  }
+
+  let root: unknown;
+  try {
+    root = JSON.parse(propsAttr);
+  } catch (err) {
+    return [
+      {
+        path: "props",
+        reason: `props attribute is not valid JSON: ${(err as Error).message}`,
+        preview: previewValue(propsAttr),
+      },
+    ];
+  }
+
+  const offenders: NonRevivableProp[] = [];
+
+  // Mirrors `reviveTuple`: `raw` must be a `[type, value]` array.
+  const walkTuple = (raw: unknown, path: string): void => {
+    if (!Array.isArray(raw)) {
+      offenders.push({
+        path,
+        reason:
+          `not a [type, value] tuple — astro's \`const [type, value] = raw\` ` +
+          `throws "${raw === null ? "null" : typeof raw} is not iterable" here`,
+        preview: previewValue(raw),
+      });
+      return;
+    }
+
+    const [type, value] = raw as [unknown, unknown];
+    if (typeof type !== "number" || !KNOWN_PROP_TYPES.has(type)) {
+      offenders.push({
+        path,
+        reason: `unknown prop type ${previewValue(type)} (astro would revive this as undefined)`,
+        preview: previewValue(value),
+      });
+      return;
+    }
+
+    // type 0 = plain object: every own-property value must itself be a tuple.
+    if (type === 0) {
+      if (value !== null && typeof value === "object") {
+        for (const [key, entry] of Object.entries(value)) {
+          walkTuple(entry, `${path}.${key}`);
+        }
+      }
+      return;
+    }
+
+    // type 1/4/5 = array-ish: astro calls `value.map(reviveTuple)`.
+    if (ARRAY_PAYLOAD_TYPES.has(type)) {
+      if (!Array.isArray(value)) {
+        offenders.push({
+          path,
+          reason:
+            `type ${type} payload must be an array (astro calls \`value.map(...)\`) ` +
+            `but got ${value === null ? "null" : typeof value}`,
+          preview: previewValue(value),
+        });
+        return;
+      }
+      for (const [index, entry] of value.entries()) {
+        walkTuple(entry, `${path}[${index}]`);
+      }
+      return;
+    }
+
+    // types 2,3,6–11 revive from a scalar payload — nothing to recurse into.
+  };
+
+  // Top level mirrors `reviveObject(JSON.parse(props))`: `{ propName: tuple }`.
+  if (root !== null && typeof root === "object" && !Array.isArray(root)) {
+    for (const [key, entry] of Object.entries(root)) {
+      walkTuple(entry, key);
+    }
+  } else {
+    offenders.push({
+      path: "(root)",
+      reason: "props root is not a plain object",
+      preview: previewValue(root),
+    });
+  }
+
+  return offenders;
+}
+
+/**
+ * Read the `props` attribute off every `<astro-island>` and build a
+ * human-readable report of the non-revivable prop paths. Returns "" when every
+ * island's props revive cleanly. The `props` attribute is emitted at SSR time,
+ * so it's present even when a revival throw leaves the island stuck with `ssr`.
+ */
+async function diagnoseIslandProps(islands: Locator): Promise<string> {
+  const propAttrs = await islands.evaluateAll((nodes) =>
+    nodes.map((node) => node.getAttribute("props"))
+  );
+
+  const sections: string[] = [];
+  for (const [index, attr] of propAttrs.entries()) {
+    const offenders = collectNonRevivableProps(attr);
+    if (offenders.length === 0) {
+      continue;
+    }
+
+    const lines = offenders.map(
+      (o) => `    • ${o.path}\n        ${o.reason}\n        value: ${o.preview}`
+    );
+    sections.push(
+      `  <astro-island>[${index}] — ${offenders.length} non-revivable prop(s):\n${lines.join("\n")}`
+    );
+  }
+
+  return sections.length
+    ? `\n\nOffending island props (break astro hydration):\n${sections.join("\n")}`
+    : "";
+}
 
 test.describe("Svelte island hydration", () => {
   for (const route of ISLAND_ROUTES) {
@@ -43,17 +207,24 @@ test.describe("Svelte island hydration", () => {
 
       // Sanity: the page actually ships an island to hydrate, otherwise this test
       // would pass vacuously if the form were ever removed/renamed.
+      const islands = page.locator("astro-island");
       await expect(
-        page.locator("astro-island").first(),
+        islands.first(),
         `no <astro-island> found on ${route} — nothing to hydrate`
       ).toBeAttached();
+
+      // Inspect the serialized `props` up front (they're present at SSR time,
+      // before hydration runs) and point at any prop that can't be revived. This
+      // is what surfaces "TypeError: … is not iterable" as a concrete prop path
+      // instead of an opaque island failure.
+      const propsDiagnostics = await diagnoseIslandProps(islands);
 
       // General success signal: Astro removes the `ssr` attribute in `hydrate()`
       // only *after* the client component mounts. Any hydration throw (bad props,
       // runtime error, mismatch, …) leaves `ssr` in place, regardless of cause.
       await expect
         .poll(() => page.locator("astro-island[ssr]").count(), {
-          message: `an <astro-island> on ${route} never finished hydrating (still has [ssr])`,
+          message: `an <astro-island> on ${route} never finished hydrating (still has [ssr])${propsDiagnostics}`,
           timeout: 10_000,
         })
         .toBe(0);
@@ -61,7 +232,7 @@ test.describe("Svelte island hydration", () => {
       const hydrationErrors = errors.filter((entry) => HYDRATION_ERROR.test(entry));
       expect(
         hydrationErrors,
-        `hydration errors on ${route}:\n${hydrationErrors.join("\n")}`
+        `hydration errors on ${route}:\n${hydrationErrors.join("\n")}${propsDiagnostics}`
       ).toEqual([]);
     });
   }


### PR DESCRIPTION
So they are enforced not to drift apart. Also allow remote tina images to be fetched build-time.